### PR TITLE
Changes default make lint to cover all versioned Python files

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -51,7 +51,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .pytest_cache
 
 lint: ## check style with flake8
-	flake8 {{ cookiecutter.project_slug }} tests
+	flake8 $(shell git ls-files '*py')
 
 test: ## run tests quickly with the default Python
 {%- if cookiecutter.use_pytest == 'y' %}


### PR DESCRIPTION
Change default lint to cover all versioned Python files - 
previous config would miss config/helper scripts at the package root. 